### PR TITLE
Update release.yml from `main` branch to `master` branch.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build-and-release:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change updates the branch name from `main` to `master` for the release workflow.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L6-R6): Changed the branch name from `main` to `master` under the `push` event configuration.